### PR TITLE
QTI in: Use `imageclozeassociationV2` for `graphicGapMatchInteraction`

### DIFF
--- a/src/Processors/QtiV2/In/Interactions/GraphicGapMatchInteractionMapper.php
+++ b/src/Processors/QtiV2/In/Interactions/GraphicGapMatchInteractionMapper.php
@@ -48,7 +48,7 @@ class GraphicGapMatchInteractionMapper extends AbstractInteractionMapper
         }
 
         $question = new imageclozeassociation(
-            'imageclozeassociation',
+            'imageclozeassociationV2',
             $image,
             $responsePosition,
             array_values($possibleResponseMapping)


### PR DESCRIPTION
This change replaces the converted question type for `graphicGapMatchInteraction` from the legacy `imageclozeassociation` to `imageclozeassociationV2`.